### PR TITLE
normalize "%C2%A0"

### DIFF
--- a/src/Normalizer/Encode.php
+++ b/src/Normalizer/Encode.php
@@ -46,6 +46,6 @@ final class Encode implements NormalizerInterface
             $userAgent = preg_replace('/\+(?!\+)/', ' ', $userAgent);
         }
 
-        return str_replace(['%20', '%2C'], [' ', ','], (string) $userAgent);
+        return str_replace(['%20', '%2C', '%C2%A0'], [' ', ',', ' '], (string) $userAgent);
     }
 }

--- a/tests/Normalizer/EncodeTest.php
+++ b/tests/Normalizer/EncodeTest.php
@@ -91,6 +91,10 @@ final class EncodeTest extends TestCase
                 'Incoming!/1.4.3 CFNetwork/454.11.5 Darwin/10.6.0 (i386) (MacBookAir2%2C1)',
                 'Incoming!/1.4.3 CFNetwork/454.11.5 Darwin/10.6.0 (i386) (MacBookAir2,1)',
             ],
+            [
+                'AI%C2%A0Chat/1742 CFNetwork/1496.0.7 Darwin/23.5.0',
+                'AI Chat/1742 CFNetwork/1496.0.7 Darwin/23.5.0',
+            ],
         ];
     }
 }

--- a/tests/Normalizer/NormalizerChainTest.php
+++ b/tests/Normalizer/NormalizerChainTest.php
@@ -437,6 +437,10 @@ final class NormalizerChainTest extends TestCase
                 'Mozilla/5.0 (Linux; U; Android 9; ko-kr; Redmi Note 8 Build/PKQ1.190616.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.6.2-gn comdirect/1.0 (appVersion:20.9.4;deviceName:nokia 8;deviceType:mobile)',
                 'Mozilla/5.0 (Linux; Android 9; Redmi Note 8 Build/PKQ1.190616.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.6.2-gn',
             ],
+            [
+                'AI%C2%A0Chat/1742 CFNetwork/1496.0.7 Darwin/23.5.0',
+                'AI Chat/1742 CFNetwork/1496.0.7 Darwin/23.5.0',
+            ],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Die Verarbeitung von Benutzeragent-Strings wurde korrigiert, um speziell kodierte Leerzeichen ordnungsgemäß zu normalisieren und eine konsistente Formatierung während der Verarbeitung zu gewährleisten.

* **Tests**
  * Neue Testfälle wurden hinzugefügt, um die korrekte Normalisierung von verschiedenen Arten von codierten Leerzeichen in Benutzeragent-Strings zu validieren. Dies stellt sicher, dass alle anderen Token und Informationen während der Normalisierung erhalten bleiben.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->