### PR TITLE
remove locale hi-in

### DIFF
--- a/src/Normalizer/LocaleRemover.php
+++ b/src/Normalizer/LocaleRemover.php
@@ -25,7 +25,7 @@ use function str_replace;
  */
 final class LocaleRemover implements NormalizerInterface
 {
-    private const string REGEX = '/(?P<prefix>; ?)(?P<lang>a[defgilmoqrstuwxz]|b[abdefghijlmnoqrstvwyz]|c[acdfghiklmnorsuvwxyz]|d[ejkmoz]|e[ceghlnrst]|f[aijkmor]|g[abdefghilmnpqrstuwy]|h[kmnrtu]|i[delmnoqrst]|j[aemop]|k[eghimnoprwyz]|l[abcgikrstuvy]|m[acdefghklmnopqrstuvwxyz]|n[acefgilopruz]|om|[pP][aefghklmnrstwy]|qa|r[eosuw]|s[abcdeghijklmnorstvxyz]|t[cdfghjklmnortvwz]|u[agkmsyz]|v[aceginu]|w[fs]|y[et]|zh-[hH]ans|z[ahmw])(?P<state>[-_]r?[a-zA-Z0-9]{2,3})?(?P<utf>\.utf8|\.big5)?(?P<b>\b-?)(?!:)(?P<end>[;)])/';
+    private const string REGEX = '/(?P<prefix>; ?)(?P<lang>a[defgilmoqrstuwxz]|b[abdefghijlmnoqrstvwyz]|c[acdfghiklmnorsuvwxyz]|d[ejkmoz]|e[ceghlnrst]|f[aijkmor]|g[abdefghilmnpqrstuwy]|h[ikmnrtu]|i[delmnoqrst]|j[aemop]|k[eghimnoprwyz]|l[abcgikrstuvy]|m[acdefghklmnopqrstuvwxyz]|n[acefgilopruz]|om|[pP][aefghklmnrstwy]|qa|r[eosuw]|s[abcdeghijklmnorstvxyz]|t[cdfghjklmnortvwz]|u[agkmsyz]|v[aceginu]|w[fs]|y[et]|zh-[hH]ans|z[ahmw])(?P<state>[-_]r?[a-zA-Z0-9]{2,3})?(?P<utf>\.utf8|\.big5)?(?P<b>\b-?)(?!:)(?P<end>[;)])/';
 
     /** @throws void */
     #[Override]

--- a/tests/Normalizer/LocaleRemoverTest.php
+++ b/tests/Normalizer/LocaleRemoverTest.php
@@ -235,6 +235,10 @@ final class LocaleRemoverTest extends TestCase
                 'UCWEB/2.0 (Java; U; MIDP-2.0; Pt-BR; maui e800) U2/1.0.0 UCBrowser/9.2.0.311 U2/1.0.0 Mobile UNTRUSTED/1.0',
                 'UCWEB/2.0 (Java; U; MIDP-2.0; maui e800) U2/1.0.0 UCBrowser/9.2.0.311 U2/1.0.0 Mobile UNTRUSTED/1.0',
             ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 16; hi-in; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
+                'Mozilla/5.0 (Linux; U; Android 16; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
+            ],
         ];
     }
 }

--- a/tests/Normalizer/NormalizerChainTest.php
+++ b/tests/Normalizer/NormalizerChainTest.php
@@ -497,6 +497,10 @@ final class NormalizerChainTest extends TestCase
                 'UCWEB/2.0 (Java; U; MIDP-2.0; Pt-BR; maui e800) U2/1.0.0 UCBrowser/9.2.0.311 U2/1.0.0 Mobile UNTRUSTED/1.0',
                 'UCWEB/2.0 (Java; MIDP-2.0; maui e800) U2/1.0.0 UCBrowser/9.2.0.311 U2/1.0.0 Mobile UNTRUSTED/1.0',
             ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 16; hi-in; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
+                'Mozilla/5.0 (Linux; Android 16; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
+            ],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Fehlerbehebungen**
  * Die Normalisierung von User-Agent-Angaben entfernt nun auch die Locale `hi-in` zuverlässig.
  * Android-16-User-Agents mit HeyTapBrowser werden korrekt ohne überflüssige Sprach- und Layout-Informationen normalisiert.

* **Tests**
  * Zusätzliche Testfälle sichern die korrekte Verarbeitung dieser User-Agent-Varianten ab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->