### PR TITLE
normalize Brand names for Meizu und Tecno

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         SetList::DEAD_CODE,
         LevelSetList::UP_TO_PHP_85,
-        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_120,
     ]);
 
     $rectorConfig->skip(

--- a/src/Normalizer/NormalizeBrandNames.php
+++ b/src/Normalizer/NormalizeBrandNames.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the ua-normalizer package.
+ *
+ * Copyright (c) 2015-2026, Thomas Mueller <mimmi20@live.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace UaNormalizer\Normalizer;
+
+use Override;
+
+use function str_ireplace;
+
+/**
+ * User Agent Normalizer - normalize brand names
+ */
+final class NormalizeBrandNames implements NormalizerInterface
+{
+    /** @throws void */
+    #[Override]
+    public function normalize(string $userAgent): string
+    {
+        $userAgent = str_ireplace(
+            ['TECNO TECNO', 'TECNO MOBILE LIMITED TECNO', 'TECNO Mobile'],
+            'TECNO',
+            $userAgent,
+        );
+
+        return str_ireplace(
+            ['MZ-MEIZU'],
+            'MEIZU',
+            $userAgent,
+        );
+    }
+}

--- a/src/NormalizerFactory.php
+++ b/src/NormalizerFactory.php
@@ -50,6 +50,7 @@ final class NormalizerFactory
                 new Normalizer\WindowsNt(),
                 new Normalizer\SerialNumbers(),
                 new Normalizer\TransferEncoding(),
+                new Normalizer\NormalizeBrandNames(),
                 new Normalizer\Trim(),
             ],
         );

--- a/tests/Normalizer/NormalizeBrandNamesTest.php
+++ b/tests/Normalizer/NormalizeBrandNamesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the ua-normalizer package.
+ *
+ * Copyright (c) 2015-2026, Thomas Mueller <mimmi20@live.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types = 1);
+
+namespace Normalizer;
+
+use Override;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\ExpectationFailedException;
+use PHPUnit\Framework\TestCase;
+use UaNormalizer\Normalizer\NormalizeBrandNames;
+
+final class NormalizeBrandNamesTest extends TestCase
+{
+    private NormalizeBrandNames $normalizer;
+
+    /**
+     * Sets up the fixture, for example, open a network connection.
+     * This method is called before a test is executed.
+     *
+     * @throws void
+     */
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->normalizer = new NormalizeBrandNames();
+    }
+
+    /** @throws ExpectationFailedException */
+    #[DataProvider('userAgentsDataProvider')]
+    public function testShouldNormalize(string $userAgent, string $expected): void
+    {
+        $found = $this->normalizer->normalize($userAgent);
+        self::assertSame($expected, $found);
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     *
+     * @throws void
+     */
+    public static function userAgentsDataProvider(): array
+    {
+        return [
+            [
+                'Mozilla/5.0 (Linux; Android 13; TECNO TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 13; TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; TECNO Mobile KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 13; TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; Android 11; TECNO MOBILE LIMITED TECNO KG5n; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 11; TECNO KG5n; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 14; zh-CN; MZ-MEIZU 20 Inf Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 MZBrowser/11.0.5 Mobile Safari/537.36',
+                'Mozilla/5.0 (Linux; U; Android 14; zh-CN; MEIZU 20 Inf Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 MZBrowser/11.0.5 Mobile Safari/537.36',
+            ],
+        ];
+    }
+}

--- a/tests/Normalizer/NormalizerChainTest.php
+++ b/tests/Normalizer/NormalizerChainTest.php
@@ -121,7 +121,7 @@ final class NormalizerChainTest extends TestCase
     {
         $chain = (new NormalizerFactory())->build();
 
-        self::assertSame(20, $chain->count());
+        self::assertSame(21, $chain->count());
         self::assertSame($expected, $chain->normalize($userAgent));
     }
 
@@ -500,6 +500,22 @@ final class NormalizerChainTest extends TestCase
             [
                 'Mozilla/5.0 (Linux; U; Android 16; hi-in; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
                 'Mozilla/5.0 (Linux; Android 16; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; TECNO TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 13; TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; TECNO Mobile KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 13; TECNO KJ6; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; Android 11; TECNO MOBILE LIMITED TECNO KG5n; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+                'Mozilla/5.0 (Linux; Android 11; TECNO KG5n; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/149.0.7827.91 Mobile Safari/537.36 Sapphire/1.11.1',
+            ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 14; zh-CN; MZ-MEIZU 20 Inf Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 MZBrowser/11.0.5 Mobile Safari/537.36',
+                'Mozilla/5.0 (Linux; Android 14; MEIZU 20 Inf Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 MZBrowser/11.0.5 Mobile Safari/537.36',
             ],
         ];
     }

--- a/tests/NormalizerFactoryTest.php
+++ b/tests/NormalizerFactoryTest.php
@@ -43,6 +43,6 @@ final class NormalizerFactoryTest extends TestCase
         $chain = $this->normalizer->build();
 
         self::assertInstanceOf(NormalizerChain::class, $chain);
-        self::assertSame(20, $chain->count());
+        self::assertSame(21, $chain->count());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Neue Funktionen**
  * User-Agent-Markenvarianten werden vereinheitlicht, einschließlich verschiedener TECNO-Schreibweisen und „MZ-MEIZU“ zu „MEIZU“.
  * Die automatische User-Agent-Normalisierung berücksichtigt diese Bereinigungen nun standardmäßig.

* **Tests**
  * Neue Testfälle für die Marken-Normalisierung und zusätzliche Android-User-Agents ergänzt.
  * Bestehende Erwartungen an die erweiterte Normalisierungskette aktualisiert.

* **Wartung**
  * PHPUnit-Kompatibilität auf den aktuellen Regelwerksstand aktualisiert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->