### PR TITLE
update normalizers

### DIFF
--- a/src/Normalizer/LocaleRemover.php
+++ b/src/Normalizer/LocaleRemover.php
@@ -39,6 +39,7 @@ final class LocaleRemover implements NormalizerInterface
             '/ +zh_CN_#Hans;/i',
             '/ +xx;/i',
             '/ +\-;/i',
+            '/ %lang2%;/i',
         ];
 
         foreach ($removals as $removal) {

--- a/src/Normalizer/NormalizeBrandNames.php
+++ b/src/Normalizer/NormalizeBrandNames.php
@@ -15,6 +15,7 @@ namespace UaNormalizer\Normalizer;
 
 use Override;
 
+use function preg_match;
 use function preg_replace;
 use function str_ireplace;
 
@@ -38,6 +39,13 @@ final class NormalizeBrandNames implements NormalizerInterface
             'MEIZU',
             $userAgent,
         );
+
+        if (
+            preg_match('/(moto(?:rola)? [eg][^-]+)[^)\/]*\)/i', $userAgent)
+            && preg_match('/(moto(?:rola)? [eg].+ -)[^)\/]*\)/i', $userAgent)
+        ) {
+            return $userAgent;
+        }
 
         return preg_replace('/(moto(?:rola)? [eg][^-]+)[^)\/]*\)/i', '$1)', $userAgent);
     }

--- a/src/Normalizer/RemoveBuild.php
+++ b/src/Normalizer/RemoveBuild.php
@@ -27,11 +27,15 @@ final class RemoveBuild implements NormalizerInterface
     public function normalize(string $userAgent): string | null
     {
         $userAgent = preg_replace(
-            '/;? +build\/(?!mocordroid)[^)]+(; cronet| \[fban|; cyanogenmod| yunos)/i',
+            '/;? +build\/(?!mocordroid|yunos|nook|aliyunos|manufacturer)[^)]+(; cronet| \[fban|; cyanogenmod| yunos|; windows)/i',
             '$1',
             $userAgent,
         );
 
-        return preg_replace('/;? +build\/(?!mocordroid)[^)]+/i', '', (string) $userAgent);
+        return preg_replace(
+            '/;? +build\/(?!mocordroid|yunos|nook|aliyunos|manufacturer)[^)]+/i',
+            '',
+            (string) $userAgent,
+        );
     }
 }

--- a/tests/Normalizer/LocaleRemoverTest.php
+++ b/tests/Normalizer/LocaleRemoverTest.php
@@ -239,6 +239,10 @@ final class LocaleRemoverTest extends TestCase
                 'Mozilla/5.0 (Linux; U; Android 16; hi-in; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
                 'Mozilla/5.0 (Linux; U; Android 16; CPH2751 Build/BP2A.250605.015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.5970.168 Mobile Safari/537.36 HeyTapBrowser/45.14.3.1',
             ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 2.3.4; %lang2%; Kindle Fire Build/GINGERBREAD) adbeat.com/policy AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+                'Mozilla/5.0 (Linux; U; Android 2.3.4; Kindle Fire Build/GINGERBREAD) adbeat.com/policy AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+            ],
         ];
     }
 }

--- a/tests/Normalizer/NormalizeBrandNamesTest.php
+++ b/tests/Normalizer/NormalizeBrandNamesTest.php
@@ -107,6 +107,10 @@ final class NormalizeBrandNamesTest extends TestCase
                 'Mozilla/5.0 (Linux; Android 9; meizu M10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
                 'Mozilla/5.0 (Linux; Android 9; meizu M10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
             ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023 Build/T1TGN33.60-55; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023 Build/T1TGN33.60-55; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+            ],
         ];
     }
 }

--- a/tests/Normalizer/NormalizerChainTest.php
+++ b/tests/Normalizer/NormalizerChainTest.php
@@ -565,6 +565,14 @@ final class NormalizerChainTest extends TestCase
                 'Mozilla/5.0 (Linux; Android 9; meizu M10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
                 'Mozilla/5.0 (Linux; Android 9; meizu M10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
             ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023 Build/T1TGN33.60-55; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+            ],
+            [
+                'Mozilla/5.0 (Linux; U; Android 2.3.4; %lang2%; Kindle Fire Build/GINGERBREAD) adbeat.com/policy AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+                'Mozilla/5.0 (Linux; Android 2.3.4; Kindle Fire) adbeat.com/policy AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+            ],
         ];
     }
 }

--- a/tests/Normalizer/RemoveBuildTest.php
+++ b/tests/Normalizer/RemoveBuildTest.php
@@ -103,6 +103,10 @@ final class RemoveBuildTest extends TestCase
                 'Mozilla/5.0 (Linux; Android 9; meizu M10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
                 'Mozilla/5.0 (Linux; Android 9; meizu M10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/88.0.4324.93 Mobile Safari/537.36 YandexSearch/7.40 YandexSearchBrowser/7.40',
             ],
+            [
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023 Build/T1TGN33.60-55; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+                'Mozilla/5.0 (Linux; Android 13; moto g stylus 5G - 2023) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36',
+            ],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Verbesserungen**
  * User-Agent-Normalisierung entfernt zusätzliche Sprach-, Build- und Gerätekennungen.
  * Motorola-User-Agents mit bestimmten Mustern bleiben unverändert erhalten.
  * Weitere nachfolgende Marker, unter anderem für CyanogenMod, YunoOS und Windows, werden korrekt verarbeitet.

* **Tests**
  * Zusätzliche Testfälle für Sprachplatzhalter, Motorola-Geräte, Kindle-Fire- und Android-User-Agents ergänzt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->